### PR TITLE
Add retry logic for meditation session save failures

### DIFF
--- a/HrvAlgorithms/sources/activity/HrActivity.mc
+++ b/HrvAlgorithms/sources/activity/HrActivity.mc
@@ -138,9 +138,14 @@ module HrvAlgorithms {
 			return summary;
 		}
 								
-		function finish() {		
-			me.mFitSession.save();
-			me.mFitSession = null;
+		function finish() {
+			try {
+				me.mFitSession.save();
+				me.mFitSession = null;
+				return true;
+			} catch (e) {
+				return false;
+			}
 		}
 			
 		function discard() {		

--- a/Meditate/resources/strings/strings.xml
+++ b/Meditate/resources/strings/strings.xml
@@ -1,6 +1,7 @@
 <strings>
     <string id="AppName">Meditate</string>
     <string id="ConfirmSaveHeader">Save Session?</string>
+    <string id="RetrySaveHeader">Save Failed. Retry?</string>
     <string id="summaryRollupMenu_title">Sessions Summary</string>
     <string id="summaryRollupMenuOption_exit">Exit</string>
 	<string id="activityDelayedFinishingText">Finishing...</string>

--- a/Meditate/source/activity/MeditateDelegate.mc
+++ b/Meditate/source/activity/MeditateDelegate.mc
@@ -38,12 +38,25 @@ class MeditateDelegate extends Ui.BehaviorDelegate {
     	Ui.switchToView(summaryViewDelegate.createScreenPickerView(), summaryViewDelegate, Ui.SLIDE_LEFT);  
     }
     
-    function onShowNextViewConfirmDialog() {      
+    function onShowNextViewConfirmDialog() {
     	onShowNextView();
-     	
+
     	var confirmSaveHeader = Ui.loadResource(Rez.Strings.ConfirmSaveHeader);
     	var confirmSaveDialog = new Ui.Confirmation(confirmSaveHeader);
-        Ui.pushView(confirmSaveDialog, new YesNoDelegate(me.mMeditateActivity.method(:finish), me.mMeditateActivity.method(:discard)), Ui.SLIDE_IMMEDIATE);
+        Ui.pushView(confirmSaveDialog, new YesNoDelegate(method(:onConfirmSave), me.mMeditateActivity.method(:discard)), Ui.SLIDE_IMMEDIATE);
+    }
+
+    function onConfirmSave() {
+    	var saved = me.mMeditateActivity.finish();
+    	if (!saved) {
+    		onRetrySave();
+    	}
+    }
+
+    function onRetrySave() {
+    	var retrySaveHeader = Ui.loadResource(Rez.Strings.RetrySaveHeader);
+    	var retrySaveDialog = new Ui.Confirmation(retrySaveHeader);
+    	Ui.pushView(retrySaveDialog, new YesNoDelegate(method(:onConfirmSave), me.mMeditateActivity.method(:discard)), Ui.SLIDE_IMMEDIATE);
     }
     
     function onShowNextView() {    


### PR DESCRIPTION
## Summary
This PR adds error handling and retry functionality for meditation session saves. When a save operation fails, users are now prompted to retry instead of silently failing.

## Key Changes
- **HrActivity.finish()**: Modified to return a boolean indicating success/failure and wrapped the save operation in a try-catch block to handle exceptions gracefully
- **MeditateDelegate**: 
  - Added `onConfirmSave()` method that checks the result of the finish operation and triggers a retry dialog on failure
  - Added `onRetrySave()` method that displays a retry confirmation dialog with the same save/discard options
  - Updated `onShowNextViewConfirmDialog()` to call the new `onConfirmSave()` method instead of directly calling `finish()`
- **strings.xml**: Added new string resource `RetrySaveHeader` for the retry dialog prompt

## Implementation Details
- The save operation now returns `true` on success and `false` on failure, allowing the delegate to respond appropriately
- The retry dialog reuses the same `YesNoDelegate` pattern, allowing users to retry the save or discard the session
- Exception handling is centralized in the `finish()` method, keeping error logic in one place

https://claude.ai/code/session_019dERne2DoAaowNMkfQXtbi